### PR TITLE
Propose collapsing dimensions/lengths into `sizes` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,7 @@ Theme Key         | CSS Properties
 `fontWeights`     | `font-weight`
 `lineHeights`     | `line-height`
 `letterSpacings`  | `letter-spacing`
-`maxWidths`       | `max-width`
-`minWidths`       | `min-widths`
-`widths`          | `width`
-`maxHeights`      | `max-height`
-`minHeights`      | `min-height`
-`heights`         | `height`
+`sizes`           | `width`, `height`, `min-width`, `max-width`, `min-height`, `max-height`
 `borders`         | `border`, `border-top`, `border-right`, `border-bottom`, `border-left`
 `borderWidths`    | `border-width`
 `borderStyles`    | `border-style`


### PR DESCRIPTION
A thought occurred to me the other day that it might make more sense to collapse width and height properties into a single field, similar to how `space` is currently treated. It seems like the same values could be reused for different properties. This is similar to something @ianstormtaylor [proposed on twitter](https://mobile.twitter.com/ianstormtaylor/status/1108018784663560192) with *lengths*.

Possible, alternative names to consider:
- `sizes`
- `dimensions`
- `lengths`
- Other? Please comment

It's worth noting that `<length>` has a specific meaning in CSS that is slightly different than the possible values here (e.g. percentages), which is part of the reason for using `sizes` in this PR 
